### PR TITLE
Check if 'case_start_time' exists to avoid AttributeError

### DIFF
--- a/juxd/__init__.py
+++ b/juxd/__init__.py
@@ -65,7 +65,7 @@ class JUXDTestResult(TextTestResult):
         run_time_taken = time.time() - self.run_start_time
         self.tree.set('name', 'Django Project Tests')
         self.tree.set('errors', str(len(self.errors)))
-        self.tree.set('failures' , str(len(self.failures)))
+        self.tree.set('failures', str(len(self.failures)))
         self.tree.set('skips', str(len(self.skipped)))
         self.tree.set('tests', str(self.testsRun))
         self.tree.set('time', "%.3f" % run_time_taken)
@@ -75,7 +75,11 @@ class JUXDTestResult(TextTestResult):
         super(JUXDTestResult, self).stopTestRun()
 
     def _make_testcase_element(self, test):
-        time_taken = time.time() - self.case_start_time
+        # In some failure scenarios, self.case_start_time does not exist (for example if fixtures fail to load)
+        if hasattr(self, 'case_start_time'):
+            time_taken = time.time() - self.case_start_time
+        else:
+            time_taken = 0
         classname = ('%s.%s' % (test.__module__, test.__class__.__name__)).split('.')
         testcase = ET.SubElement(self.tree, 'testcase')
         testcase.set('time', "%.6f" % time_taken)

--- a/juxd/__init__.py
+++ b/juxd/__init__.py
@@ -84,7 +84,12 @@ class JUXDTestResult(TextTestResult):
         testcase = ET.SubElement(self.tree, 'testcase')
         testcase.set('time', "%.6f" % time_taken)
         testcase.set('classname', '.'.join(classname))
-        testcase.set('name', test._testMethodName)
+
+        # Sometimes `test` is an _ErrorHolder object with no _testMethodName property
+        if hasattr(test, '_testMethodName'):
+            testcase.set('name', test._testMethodName)
+        else:
+            testcase.set('name', getattr(test, 'description', '(unknown)'))
         return testcase
 
     def _add_tb_to_test(self, test, test_result, err):


### PR DESCRIPTION
Check if the `case_start_time` property exists before trying to access it, and set the time taken to 0 in that case.